### PR TITLE
Fix automation for old regression tests for VisibleV8

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Alternatively, you can download Debian packages from the [releases](https://gith
 * Clone this repository *(we will call the cloned working directory **$VV8**)*
 * Run `make build` from *inside* `$VV8/builder`, this will build the latest Chromium version with the VisibleV8 patches. You can also run `make build VERSION=104.0.5112.79` to build a specific version of Chromium, but keep in mind that we do not have patchsets for all versions of Chromium.
 * You can find the `.deb` file inside `$VV8/builder/artifacts` and install it using `dpkg -i <path-to-deb-file>`
-
+* (Optional) If you want to verify that VisibleV8 is producing logs as intended, you can run a set of regression tests using `../tests/run.sh -x $(docker ps -q -l --format={{.Image}}) trace-apis-obj`. The output will verify the output of the v8-shell against a set of pre-generated logs looking for differences between the logs.
 
 ## Log Output
 

--- a/builder/check_new_chrome_release.sh
+++ b/builder/check_new_chrome_release.sh
@@ -22,7 +22,7 @@ if [ "$LAST_RELEASE" == "$VERSION" ]; then
 else
     echo "New release is available"
     echo "Building VisibleV8 for $VERSION"
-    make build VERSION=$VERSION DEBUG=0 PUBLISH_ASSETS=1 TESTS=0
+    make build VERSION=$VERSION DEBUG=0 PUBLISH_ASSETS=1 TESTS=1
     if [ $? -eq 0 ]; then
         echo "Done building VisibleV8 for $VERSION"
         curl -X POST -H 'Content-type: application/json' --data '{"text":"VisibleV8 build for version '$VERSION' has been successful!"}' $SLACK_WEBHOOK

--- a/builder/run.sh
+++ b/builder/run.sh
@@ -21,8 +21,8 @@ if [[ "$PUBLISH_ASSETS" -eq 1 ]]; then
 fi
 
 if [[ "$TESTS" -eq 1 ]]; then
-    LATEST_IMAGE=`docker images --format='{{.ID}}' | head -1`
-    ../tests/run.sh $LATEST_IMAGE trace-apis
+    LATEST_IMAGE=`docker ps -l --format={{.Image}}`
+    ../tests/run.sh -x $LATEST_IMAGE trace-apis-obj
 fi
 
 # docker run -it --privileged --entrypoint /bin/bash -v $(pwd):/tests --user 0 visiblev8/vv8-base:104.0.5112.79

--- a/tests/logs/entry.sh
+++ b/tests/logs/entry.sh
@@ -11,27 +11,28 @@ TEST_SRC="/testsrc"
 EXPECTED_LOGS="/expected"
 SCRATCH_DIR=$(mktemp -d)
 
-if [ -x "$UNITTESTS" ]; then
-    echo "Running V8's unittests..."
-    if ! "$UNITTESTS" --gtest_filter=-SequentialUnmapperTest --gtest_output=xml:"v8_unittests_results.xml" >/dev/null 2>&1; then
-        if [ -r v8_unittests_results.xml ]; then
-            failures=$(grep "^<testsuites " v8_unittests_results.xml | grep -oP 'failures="\K\d+')
-            echo '*****************************************************************'
-            echo "WARNING: V8's unittest suite reported $failures failures!"
-            echo "         v8_unittests_results.xml should be MANUALLY INSPECTED..."
-            echo '*****************************************************************'
-            echo
-        else
-            echo '*****************************************************************'
-            echo "WARNING: V8's unittest suite did not produce an output file!"
-            echo "         you may want to run it manually to observe the output..."
-            echo '*****************************************************************'
-            echo
-        fi
-    fi
-else
-    echo "No V8 unittests found (at $UNITTESTS); skipping unit tests..."
-fi
+# V8 unit tests still don't run
+# if [ -x "$UNITTESTS" ]; then
+#     echo "Running V8's unittests..."
+#     if ! "$UNITTESTS" --gtest_filter=-SequentialUnmapperTest --gtest_output=xml:"v8_unittests_results.xml" >/dev/null 2>&1; then
+#         if [ -r v8_unittests_results.xml ]; then
+#             failures=$(grep "^<testsuites " v8_unittests_results.xml | grep -oP 'failures="\K\d+')
+#             echo '*****************************************************************'
+#             echo "WARNING: V8's unittest suite reported $failures failures!"
+#             echo "         v8_unittests_results.xml should be MANUALLY INSPECTED..."
+#             echo '*****************************************************************'
+#             echo
+#         else
+#             echo '*****************************************************************'
+#             echo "WARNING: V8's unittest suite did not produce an output file!"
+#             echo "         you may want to run it manually to observe the output..."
+#             echo '*****************************************************************'
+#             echo
+#         fi
+#     fi
+# else
+#     echo "No V8 unittests found (at $UNITTESTS); skipping unit tests..."
+# fi
 
 exitstatus=0
 if [ -x "$V8_SHELL" ]; then
@@ -45,7 +46,7 @@ if [ -x "$V8_SHELL" ]; then
 
         expected="$EXPECTED_LOGS/$sbase.log"
         actual="$SCRATCH_DIR/$sbase.actual.log"
-        mv vv8*-v8_shell.0.log "$actual"
+        mv vv8-*-vv8-shell-*.0.log "$actual"
         
         "$TOOLS/relabel.py" <"$actual" >"$SCRATCH_DIR/filtered_actual.log"
         "$TOOLS/relabel.py" <"$expected" >"$SCRATCH_DIR/filtered_expected.log"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -20,6 +20,7 @@ if [ -z "$IMAGE" -o -z "$SUITE" ]; then
 fi
 
 TEST_ROOT=$(realpath $(dirname $0))
+ARTIFACTS_DIR="$TEST_ROOT/../builder/artifacts"
 SRC_DIR="$TEST_ROOT/src"
 TOOLS_DIR="$TEST_ROOT/logs"
 SUITE_DIR="$TEST_ROOT/logs/$SUITE"
@@ -29,6 +30,7 @@ if [ ! -d "$SUITE_DIR" ]; then
 fi
 
 docker run $PRIV --rm \
+    -v "$ARTIFACTS_DIR:/artifacts:rw" \
     -v "$SRC_DIR:/testsrc:ro" \
     -v "$TOOLS_DIR:/tools:ro" \
     -v "$SUITE_DIR:/expected:ro" \


### PR DESCRIPTION
This commit fixes the automation surrounding the regressions tests introduced by Jordan. Running `make build VERSION=<version> DEBUG=0 PUBLISH_ASSETS=0 TESTS=1` should build and run tests for the specific version of Chrome.

The tests can also be run manually after build by using the following command:

`../tests/run.sh -x $(docker ps -q -l --format={{.Image}}) trace-apis-obj` (inside the builder directory)