### PR TITLE
Fix issues with adblock hanging mid-postprocessing

### DIFF
--- a/post-processor/fptp/main.go
+++ b/post-processor/fptp/main.go
@@ -69,6 +69,7 @@ var firstPartyThirdPartyFields = [...]string{
 }
 
 func (agg *fptpAggregator) DumpToPostgresql(ctx *core.AggregationContext, sqlDb *sql.DB) error {
+	log.Printf("Dumping fptp to Postgresql...")
 	var rootDomain string
 	rootDomain, err := core.GetRootDomain(sqlDb, ctx.Ln)
 

--- a/post-processor/main.go
+++ b/post-processor/main.go
@@ -282,6 +282,7 @@ func invoke(args []string, topLevel bool) error {
 		}
 
 		for _, agg := range aggregators {
+			log.Printf("Started dumping for aggregator...\n")
 			err = outputDriver(agg, &aggCtx)
 			if err != nil {
 				return err

--- a/post-processor/mega/postgresql.go
+++ b/post-processor/mega/postgresql.go
@@ -58,6 +58,7 @@ func (agg *usageAggregator) DumpToPostgresql(ctx *core.AggregationContext, sqlDb
 	if err = pctx.sqlDumpUsageCounts(sqlDb, agg); err != nil {
 		return fmt.Errorf("megaFeatures.DumpToMongresql/usageCounts: %w", err)
 	}
+	log.Printf("Mfeatures.DumpToMongresql: done.")
 	return nil
 }
 


### PR DESCRIPTION
- Removed stdin pipe due to unreliable locking behaviour
- Switch to using a temporary file to manage IPC between adblock binary and postprocessor