### PR TITLE
Tag the pushed image as latest

### DIFF
--- a/post-processor/build/publish.sh
+++ b/post-processor/build/publish.sh
@@ -8,3 +8,4 @@ else
 fi
 docker push visiblev8/vv8-postprocessors:$(git rev-parse --short HEAD)
 docker tag visiblev8/vv8-postprocessors:$(git rev-parse --short HEAD) visiblev8/vv8-postprocessors:latest
+docker push visiblev8/vv8-postprocessors:latest


### PR DESCRIPTION
Previously, the latest tag was not being applied correctly, now it should by default be applied since we are pushing the latest version to the repo as well.