### PR TITLE
Add SecurityToken associated with origin

### DIFF
--- a/patches/bb5258320e0aca193f0f/trace-apis.diff
+++ b/patches/bb5258320e0aca193f0f/trace-apis.diff
@@ -605,7 +605,7 @@ index 42c161dfa7..d41f4c3813 100644
    LanguageMode language_mode = static_cast<LanguageMode>(args.smi_value_at(3));
    Handle<SharedFunctionInfo> outer_info(args.at<JSFunction>(2)->shared(),
 diff --git a/src/runtime/runtime-test.cc b/src/runtime/runtime-test.cc
-index 8edc0a6c98..511be92b14 100644
+index 8edc0a6c98..58fd8cf508 100644
 --- a/src/runtime/runtime-test.cc
 +++ b/src/runtime/runtime-test.cc
 @@ -2,15 +2,25 @@
@@ -653,7 +653,7 @@ index 8edc0a6c98..511be92b14 100644
  
  #ifdef V8_ENABLE_MAGLEV
  #include "src/maglev/maglev.h"
-@@ -1354,6 +1372,652 @@ RUNTIME_FUNCTION(Runtime_TraceExit) {
+@@ -1354,6 +1372,660 @@ RUNTIME_FUNCTION(Runtime_TraceExit) {
    return obj;  // return TOS
  }
  
@@ -969,13 +969,21 @@ index 8edc0a6c98..511be92b14 100644
 +      // Littered with evil hacks to work around WebKit/Blink's brokenness
 +      // w.r.t. initializing its Window object
 +      if (native_global->GetEmbedderField(1).IsSmi()) {
-+        auto origin = JSReceiver::GetProperty(isolate, native_global, "origin");
-+        Handle<Object> origin_value;
-+        if (origin.ToHandle(&origin_value)) {
-+          out << '@';
-+          visv8_to_string(isolate, out, *origin_value);
-+          out << '\n';
-+          return;  // Early out
++        auto location = JSReceiver::GetProperty(isolate, native_global, "location");
++        Handle<Object> location_value;
++        if ( location.ToHandle(&location_value) ) {
++          Handle<JSReceiver> location_jsrecv =  Handle<JSReceiver>::cast(location_value);
++          auto href = JSReceiver::GetProperty(isolate, location_jsrecv, "href");
++          Object security_token = isolate->context().native_context().security_token();
++          Handle<Object> origin_value;
++          if (href.ToHandle(&origin_value)) {
++            out << '@';
++            visv8_to_string(isolate, out, *origin_value);
++            out << ":";
++            visv8_to_string(isolate, out, security_token);
++            out << '\n';
++            return;  // Early out
++          }
 +        }
 +      }
 +    }

--- a/post-processor/adblock/main.go
+++ b/post-processor/adblock/main.go
@@ -60,7 +60,7 @@ func NewAdblockAggregator() (core.Aggregator, error) {
 }
 
 func (agg *adblockAggregator) IngestRecord(ctx *core.ExecutionContext, lineNumber int, op byte, fields []string) error {
-	if (ctx.Script != nil) && !ctx.Script.VisibleV8 && (ctx.Origin != "") {
+	if (ctx.Script != nil) && !ctx.Script.VisibleV8 && (ctx.Origin.Origin != "") {
 		_, ok := agg.scriptList[ctx.Script.ID]
 
 		if !ok {
@@ -88,7 +88,7 @@ func (agg *adblockAggregator) sendURLsToAdblock() error {
 	var cnt int = 0
 
 	for _, script := range agg.scriptList {
-		if script.info.URL == "" || script.info.FirstOrigin == "null" {
+		if script.info.URL == "" || script.info.FirstOrigin.Origin == "null" {
 			continue
 		}
 

--- a/post-processor/callargs/callargs.go
+++ b/post-processor/callargs/callargs.go
@@ -44,7 +44,7 @@ func NewCreateCallArgsAggregator() (core.Aggregator, error) {
 
 // IngestRecord parses a trace record, looking for document.createElement calls to track
 func (agg *CreateCallArgsAggregator) IngestRecord(ctx *core.ExecutionContext, lineNumber int, op byte, fields []string) error {
-	if (op == 'c') && (ctx.Script != nil) && !ctx.Script.VisibleV8 && (ctx.Origin != "") {
+	if (op == 'c') && (ctx.Script != nil) && !ctx.Script.VisibleV8 && (ctx.Origin.Origin != "") {
 		offset, err := strconv.Atoi(fields[0])
 		if err != nil {
 			return fmt.Errorf("%d: invalid script offset '%s'", lineNumber, fields[0])
@@ -69,7 +69,7 @@ func (agg *CreateCallArgsAggregator) IngestRecord(ctx *core.ExecutionContext, li
 		}
 
 		// Create the call site to record
-		cite := originCallsite{ctx.Origin, ctx.Script, offset, fullName}
+		cite := originCallsite{ctx.Origin.Origin, ctx.Script, offset, fullName}
 		args := agg.callInfo[cite]
 		if args == nil {
 			args = make([][]string, 0)

--- a/post-processor/causality/causality.go
+++ b/post-processor/causality/causality.go
@@ -81,7 +81,7 @@ func (agg *ScriptCausalityAggregator) addInsertion(codeHash core.ScriptHash, act
 
 // IngestRecord processes a single trace record (line), looking for dynamic script causality
 func (agg *ScriptCausalityAggregator) IngestRecord(ctx *core.ExecutionContext, lineNumber int, op byte, fields []string) error {
-	if (ctx.Script != nil) && !ctx.Script.VisibleV8 && (ctx.Origin != "") {
+	if (ctx.Script != nil) && !ctx.Script.VisibleV8 && (ctx.Origin.Origin != "") {
 		var name, rcvr string
 		switch op {
 		case 's':

--- a/post-processor/core/annotate.go
+++ b/post-processor/core/annotate.go
@@ -54,7 +54,8 @@ func AnnotateStream(stream io.Reader, aggCtx *AggregationContext) error {
 				}
 			case '@':
 				originString, _ := StripQuotes(fields[0])
-				ln.changeOrigin(originString)
+				originSecurityToken, _ := StripQuotes(fields[1])
+				ln.changeOrigin(originString, originSecurityToken)
 			default:
 				offset, err := strconv.Atoi(fields[0])
 				if err != nil {

--- a/post-processor/core/core.go
+++ b/post-processor/core/core.go
@@ -216,8 +216,11 @@ func (ln *LogInfo) changeScript(id int) {
 	ln.World.Context.Script = script
 }
 
-func (ln *LogInfo) changeOrigin(url string) {
-	ln.World.Context.Origin = url
+func (ln *LogInfo) changeOrigin(url string, security_token string) {
+	ln.World.Context.Origin = &Origin{
+		Origin:              url,
+		OriginSecurityToken: security_token,
+	}
 }
 
 // NewIsolateInfo constructs a fresh, empty IsolateInfo for a given hex-string pointer tag
@@ -248,7 +251,7 @@ func NewScriptHash(code string) ScriptHash {
 }
 
 // NewScriptInfo constructs a new script in a given Isolate with the given runtime ID and code body
-func NewScriptInfo(iso *IsolateInfo, id int, code string, activeOrigin string) *ScriptInfo {
+func NewScriptInfo(iso *IsolateInfo, id int, code string, activeOrigin *Origin) *ScriptInfo {
 	return &ScriptInfo{
 		Isolate:     iso,
 		ID:          id,
@@ -302,7 +305,8 @@ func (ln *LogInfo) IngestStream(stream io.Reader, aggs ...Aggregator) error {
 				}
 			case '@':
 				originString, _ := StripQuotes(fields[0])
-				ln.changeOrigin(originString)
+				originSecurityToken, _ := StripQuotes(fields[1])
+				ln.changeOrigin(originString, originSecurityToken)
 			default:
 				for _, agg := range aggs {
 					err := agg.IngestRecord(&ln.World.Context, lineCount, code, fields)

--- a/post-processor/core/types.go
+++ b/post-processor/core/types.go
@@ -71,7 +71,12 @@ type LogInfo struct {
 // ExecutionContext provides context to a trace record: the active script and the enforced SOP domain (if any)
 type ExecutionContext struct {
 	Script *ScriptInfo
-	Origin string
+	Origin *Origin
+}
+
+type Origin struct {
+	Origin              string
+	OriginSecurityToken string
 }
 
 // IsolateInfo tracks a V8 isolate (i.e., script namespace, for our purposes) during processing
@@ -110,5 +115,5 @@ type ScriptInfo struct {
 	EvaledBy *ScriptInfo
 
 	// Active origin at moment of creation in the logs?
-	FirstOrigin string
+	FirstOrigin *Origin
 }

--- a/post-processor/elements/elements.go
+++ b/post-processor/elements/elements.go
@@ -47,7 +47,7 @@ func NewCreateElementAggregator() (core.Aggregator, error) {
 
 // IngestRecord parses a trace record, looking for document.createElement calls to track
 func (agg *CreateElementAggregator) IngestRecord(ctx *core.ExecutionContext, lineNumber int, op byte, fields []string) error {
-	if (op == 'c') && (ctx.Script != nil) && !ctx.Script.VisibleV8 && (ctx.Origin != "") {
+	if (op == 'c') && (ctx.Script != nil) && !ctx.Script.VisibleV8 && (ctx.Origin.Origin != "") {
 		offset, err := strconv.Atoi(fields[0])
 		if err != nil {
 			return fmt.Errorf("%d: invalid script offset '%s'", lineNumber, fields[0])
@@ -89,7 +89,7 @@ func (agg *CreateElementAggregator) IngestRecord(ctx *core.ExecutionContext, lin
 				log.Printf("field: %s\n", field)
 			}
 			if ok {
-				cite := originCallsite{ctx.Origin, ctx.Script, offset}
+				cite := originCallsite{ctx.Origin.Origin, ctx.Script, offset}
 				tagSet := agg.tagMap[cite]
 				if tagSet == nil {
 					tagSet = make(map[string]int)

--- a/post-processor/features/features.go
+++ b/post-processor/features/features.go
@@ -72,7 +72,7 @@ func NewFeatureUsageAggregator() (core.Aggregator, error) {
 
 // IngestRecord parses a trace/callsite record and aggregates API feature usage
 func (agg *FeatureUsageAggregator) IngestRecord(ctx *core.ExecutionContext, lineNumber int, op byte, fields []string) error {
-	if (ctx.Script != nil) && !ctx.Script.VisibleV8 && (ctx.Origin != "") {
+	if (ctx.Script != nil) && !ctx.Script.VisibleV8 && (ctx.Origin.Origin != "") {
 		offset, err := strconv.Atoi(fields[0])
 		if err != nil {
 			return fmt.Errorf("%d: invalid script offset '%s'", lineNumber, fields[0])
@@ -117,7 +117,7 @@ func (agg *FeatureUsageAggregator) IngestRecord(ctx *core.ExecutionContext, line
 		}
 
 		// Stick it in our aggregation map (counting)
-		agg.usage[UsageInfo{ctx.Origin, ctx.Script, offset, fullName, rune(op)}]++
+		agg.usage[UsageInfo{ctx.Origin.Origin, ctx.Script, offset, fullName, rune(op)}]++
 
 		// And track callsite polymorphism (we break feature tuple sets into mono/poly morphic for different aggregation queries)
 		morphKey := callsite{ctx.Script, offset}

--- a/post-processor/flow/main.go
+++ b/post-processor/flow/main.go
@@ -37,7 +37,7 @@ func NewAggregator() (core.Aggregator, error) {
 }
 
 func (agg *flowAggregator) IngestRecord(ctx *core.ExecutionContext, lineNumber int, op byte, fields []string) error {
-	if (ctx.Script != nil) && !ctx.Script.VisibleV8 && (ctx.Origin != "") {
+	if (ctx.Script != nil) && !ctx.Script.VisibleV8 && (ctx.Origin.Origin != "") {
 		offset, err := strconv.Atoi(fields[0])
 		if err != nil {
 			return fmt.Errorf("%d: invalid script offset '%s'", lineNumber, fields[0])

--- a/post-processor/fptp/main.go
+++ b/post-processor/fptp/main.go
@@ -42,7 +42,7 @@ func NewFptpAggregator() (core.Aggregator, error) {
 }
 
 func (agg *fptpAggregator) IngestRecord(ctx *core.ExecutionContext, lineNumber int, op byte, fields []string) error {
-	if (ctx.Script != nil) && !ctx.Script.VisibleV8 && (ctx.Origin != "") {
+	if (ctx.Script != nil) && !ctx.Script.VisibleV8 && (ctx.Origin.Origin != "") {
 		_, ok := agg.scriptList[ctx.Script.ID]
 
 		if !ok {
@@ -119,7 +119,7 @@ func (agg *fptpAggregator) DumpToPostgresql(ctx *core.AggregationContext, sqlDb 
 			return err
 		}
 
-		originURL, err := url.Parse(script.info.FirstOrigin)
+		originURL, err := url.Parse(script.info.FirstOrigin.Origin)
 
 		if err != nil {
 			return err
@@ -189,7 +189,7 @@ func (agg *fptpAggregator) DumpToStream(ctx *core.AggregationContext, stream io.
 			return err
 		}
 
-		originURL, err := url.Parse(script.info.FirstOrigin)
+		originURL, err := url.Parse(script.info.FirstOrigin.Origin)
 
 		if err != nil {
 			return err

--- a/post-processor/mega/main.go
+++ b/post-processor/mega/main.go
@@ -51,7 +51,7 @@ func NewAggregator() (core.Aggregator, error) {
 // IngestRecord does nothing for MicroScriptsAggregators (since we care only about the scripts processed by the core framework)
 func (agg *usageAggregator) IngestRecord(ctx *core.ExecutionContext, lineNumber int, op byte, fields []string) error {
 	// Only in a valid script/execution context...
-	if (ctx.Script != nil) && !ctx.Script.VisibleV8 && (ctx.Origin != "") {
+	if (ctx.Script != nil) && !ctx.Script.VisibleV8 && (ctx.Origin.Origin != "") {
 		// Raw field parsing/handling (offset, receiver/member, filtering, full-name)
 		offset, err := strconv.Atoi(fields[0])
 		if err != nil {
@@ -108,7 +108,7 @@ func (agg *usageAggregator) IngestRecord(ctx *core.ExecutionContext, lineNumber 
 		// Usage-map counting
 		usage := Usage{
 			script:  ctx.Script,
-			origin:  ctx.Origin,
+			origin:  ctx.Origin.Origin,
 			feature: feature,
 			offset:  offset,
 			mode:    rune(op),

--- a/post-processor/mega/postgresql.go
+++ b/post-processor/mega/postgresql.go
@@ -276,8 +276,8 @@ func (pctx *postgresqlContext) sqlDumpScriptInstances(sqlDb *sql.DB, ln *core.Lo
 			}
 
 			var originURLHash, scriptURLHash interface{}
-			if script.FirstOrigin != "" {
-				temp := ub.URLToHash(script.FirstOrigin)
+			if script.FirstOrigin.Origin != "" {
+				temp := ub.URLToHash(script.FirstOrigin.Origin)
 				originURLHash = temp[:]
 			}
 			if script.URL != "" {

--- a/post-processor/micro/ufeatures.go
+++ b/post-processor/micro/ufeatures.go
@@ -33,7 +33,8 @@ func NewFeatureUsageAggregator() (core.Aggregator, error) {
 
 // IngestRecord extracts minimal script API usage stats from each callsite record
 func (agg *FeatureUsageAggregator) IngestRecord(ctx *core.ExecutionContext, lineNumber int, op byte, fields []string) error {
-	if (ctx.Script != nil) && !ctx.Script.VisibleV8 && (ctx.Origin != "") {
+	log.Printf("Yo!")
+	if (ctx.Script != nil) && !ctx.Script.VisibleV8 && (ctx.Origin.Origin != "") {
 		var rcvr, name, fullName string
 		switch op {
 		case 'g':
@@ -73,10 +74,10 @@ func (agg *FeatureUsageAggregator) IngestRecord(ctx *core.ExecutionContext, line
 
 		// We log only IDL-normalized members
 		// Stick it in our aggregation map
-		originSet, ok := agg.usage[ctx.Origin]
+		originSet, ok := agg.usage[ctx.Origin.Origin]
 		if !ok {
 			originSet = make(map[string]bool)
-			agg.usage[ctx.Origin] = originSet
+			agg.usage[ctx.Origin.Origin] = originSet
 		}
 		originSet[fullName] = true
 	}


### PR DESCRIPTION
Causality requires distinguishing origins that might have the same overall URL but have different script loads, to facilitate this, add a identifiable unique string to the logs so that the postprocessor can distinguishing between origins with the same URL