### PR TITLE
Fix test build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Note: The build process for Android has been simplified. Head over to `build/bui
 * Clone this repository *(we will call the cloned working directory **$VV8**)*
 * Run `make build` from *inside* `$VV8/builder`, this will build the latest Chromium version with the VisibleV8 patches. You can also run `make build VERSION=104.0.5112.79` to build a specific version of Chromium, but keep in mind that we do not have patchsets for all versions of Chromium.
 * You can find the `.deb` file inside `$VV8/builder/artifacts` and install it using `dpkg -i <path-to-deb-file>`
-* (Optional) If you want to verify that VisibleV8 is producing logs as intended, you can run a set of regression tests using `../tests/run.sh -x $(docker ps -q -l --format={{.Image}}) trace-apis-obj`. The output will verify the output of the v8-shell against a set of pre-generated logs looking for differences between the logs.
+* (Optional) If you want to verify that VisibleV8 is producing logs as intended, you can run a set of regression tests using `../tests/run.sh -x $(docker ps -l --format={{.Image}}) trace-apis-obj`. The output will verify the output of the v8-shell against a set of pre-generated logs looking for differences between the logs.
 
 ## Log Output
 


### PR DESCRIPTION
Closes #76 

Delete the `-q` flag from the docker command because it returns the container ID and the script asks for the IMAGE name