### PR TITLE
ARM64 release of the post-processor docker image

### DIFF
--- a/.github/build-postprocessors/action.yml
+++ b/.github/build-postprocessors/action.yml
@@ -1,5 +1,17 @@
 name: 'Build postprocessors'
 description: 'Building postprocessors'
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: 'composite'
+  steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Build and push
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: false
+        tags: postprocessors:latest

--- a/.github/workflows/post-processor.yaml
+++ b/.github/workflows/post-processor.yaml
@@ -28,6 +28,10 @@ jobs:
           tags: |
             type=raw,value=latest,enable=true
             type=raw,value=${{ steps.short_sha.outputs.sha_short }},enable=true
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
I think if we used just build + push but don't push, we shouldn't need to change anything else 