### PR TITLE
[Fixes] Postprocesser Docker build failing

### DIFF
--- a/.github/build-postprocessors/Dockerfile
+++ b/.github/build-postprocessors/Dockerfile
@@ -1,7 +1,13 @@
 FROM golang:1.22 AS build
 
+# COPY post-processor /post-processor # This is for testing locally
+
 RUN apt update
 RUN apt install -y --no-install-recommends git python3 python3-pip curl make
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
 ENV PATH="${PATH}:/root/.cargo/bin"
-ENTRYPOINT [ "make", "-C", "post-processor" ]
+# WORKDIR / # This is for testing locally
+RUN make -C post-processor
+
+FROM ubuntu:latest
+COPY --from=build /post-processor/artifacts /artifacts

--- a/.github/workflows/post-processor.yaml
+++ b/.github/workflows/post-processor.yaml
@@ -10,8 +10,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-      - name: Build postprocessors
-        uses: ./.github/build-postprocessors
+      # - name: Build postprocessors
+      #   uses: ./.github/build-postprocessors
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -32,14 +32,14 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Build and push Docker image
+      - name: Build and push post-processor image
         uses: docker/build-push-action@v6
         with:
-          context: ./post-processor/
-          file: ./post-processor/build/Dockerfile.vv8
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          context: ./post-processor
+          file: ./.github/build-postprocessors/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: postprocessors:latest
       - name: Remove artifacts
         if: always()
         uses: docker://ubuntu:latest

--- a/.github/workflows/post-processor.yaml
+++ b/.github/workflows/post-processor.yaml
@@ -38,7 +38,7 @@ jobs:
           context: ./post-processor
           file: ./.github/build-postprocessors/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: false
+          push: true
           tags: postprocessors:latest
       - name: Remove artifacts
         if: always()


### PR DESCRIPTION
We should be able to overhaul the "Build in one docker, release an image from a different file" by just using a multi-stage Dockerfile.