### PR TITLE
Fix errors in build

### DIFF
--- a/.github/build-postprocessors/Dockerfile
+++ b/.github/build-postprocessors/Dockerfile
@@ -1,12 +1,12 @@
 FROM golang:1.22 AS build
 
-# COPY post-processor /post-processor # This is for testing locally
+COPY post-processor /post-processor
 
 RUN apt update
 RUN apt install -y --no-install-recommends git python3 python3-pip curl make
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
 ENV PATH="${PATH}:/root/.cargo/bin"
-# WORKDIR / # This is for testing locally
+WORKDIR /
 RUN make -C post-processor
 
 FROM ubuntu:latest


### PR DESCRIPTION
We will need to copy over the post-processor directory any way due to idiosyncrasies of docker builder