### PR TITLE
Make build system more modular

### DIFF
--- a/.github/workflows/chromium-build.yaml
+++ b/.github/workflows/chromium-build.yaml
@@ -78,7 +78,7 @@ jobs:
           env:
             VERSION: ${{ steps.get_release.outputs.chromeReleaseVersion }}
           run: |
-            cd builder && make build VERSION=$VERSION DEBUG=0 PUBLISH_ASSETS=0 TESTS=1 ANDROID=1 ARM=1
+            cd builder && make build VERSION=$VERSION DEFAULT=1 DEBUG=0 PUBLISH_ASSETS=0 TESTS=1 ANDROID=1 ARM=1 WEBVIEW=1 IDLDATA=1
         - name: Get VV8 artifact name
           if: steps.shouldPublish.outputs.shouldPublish == 'true'
           id: artifact_name

--- a/builder/Makefile
+++ b/builder/Makefile
@@ -1,9 +1,29 @@
 .PHONY: build patch-debug clean
 
+DEFAULT ?= 1
+DEBUG ?= 0
+PUBLISH_ASSETS ?= 0
+ANDROID ?= 0
+ARM ?= 0
+WEBVIEW ?= 0
+IDLDATA ?= 1
+
 build:
 	# to build a specific version, run:
 	# make build VERSION=104.0.5112.79 
-	./run.sh $(VERSION) $(DEBUG) $(PUBLISH_ASSETS) $(TESTS) $(ANDROID) $(ARM)
+	./run.sh "$(VERSION)" "$(DEFAULT)" "$(DEBUG)" "$(PUBLISH_ASSETS)" "$(TESTS)" "$(ANDROID)" "$(ARM)" "$(WEBVIEW)" "$(IDLDATA)"
+
+debug:
+	@$(MAKE) build DEFAULT=1 DEBUG=1
+
+android:
+	@$(MAKE) build ANDROID=1 DEFAULT=0
+
+arm:
+	@$(MAKE) build ARM=1 DEFAULT=0
+
+webview:
+	@$(MAKE) build WEBVIEW=1 DEFAULT=0
 
 patch-debug:
 	docker commit $$(docker ps -q -l) patch-fail

--- a/builder/run.sh
+++ b/builder/run.sh
@@ -3,15 +3,18 @@ set -ex
 
 # the visiblev8 repository that will be mounted in the container
 VV8_DIR="$(dirname `pwd`)"
+DEFAULT=${2:-""}
 VERSION=${1:-""}
-DEBUG=${2:-""}
-PUBLISH_ASSETS=${3:-""}
-TESTS=${4:-""}
-ANDROID=${5:-""}
-ARM=${6:-""}
+DEBUG=${3:-""}
+PUBLISH_ASSETS=${4:-""}
+TESTS=${5:-""}
+ANDROID=${6:-""}
+ARM=${7:-""}
+WEBVIEW=${8:-""}
+IDLDATA=${9:-""}
 
 docker build --platform linux/amd64 -t build-direct -f build-direct.dockerfile .
-docker run --platform linux/amd64 -i -v $(pwd)/artifacts:/artifacts -v $(pwd)/build:/build -v $VV8_DIR:/build/visiblev8 build-direct $VERSION $DEBUG $ANDROID $ARM
+docker run --platform linux/amd64 -i -v $(pwd)/artifacts:/artifacts -v $(pwd)/build:/build -v $VV8_DIR:/build/visiblev8 build-direct "$VERSION" "$DEFAULT" "$DEBUG" "$ANDROID" "$ARM" "$WEBVIEW" "$IDLDATA"
 
 [ ! -d $ARTIFACT_DIR ] && echo "No artifacts. Please build visiblev8 first and place all artifacts in $ARTIFACT_DIR" && exit 1;
 PACKAGE_NAME_AMD64=`find ./artifacts -name '*amd64.deb' -printf "%f\n" | sort -V | tail -n 1`


### PR DESCRIPTION
- Provide shortcuts to build different versions of VisibleV8
- Allow for a configuration where you can run `make build VERSION=X WEBVIEW=1 DEFAULT=0` and the system runs without any complaints and without complaints
- Fix issues where all arguments needed to be specified to manipulate a variable that was at the end of the list