### PR TITLE
Fix our Dockerfile woes once and for all [cn]

### DIFF
--- a/post-processor/build/Dockerfile
+++ b/post-processor/build/Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:1.24 AS builder
+
+WORKDIR /visiblev8
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git python3 python3-pip curl && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | bash -s -- -y
+ENV PATH="${PATH}:/root/.cargo/bin"
+
+RUN --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/go/pkg \
+    true
+
+COPY . .
+
+RUN make -C /visiblev8
+
+FROM ubuntu:latest AS runtime
+
+WORKDIR /
+
+COPY --from=builder /visiblev8/artifacts /artifacts

--- a/post-processor/build/Dockerfile.builder
+++ b/post-processor/build/Dockerfile.builder
@@ -1,7 +1,0 @@
-FROM golang:1.24 AS build
-
-WORKDIR /visiblev8
-RUN apt update
-RUN apt install -y --no-install-recommends git python3 python3-pip curl
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y
-ENV PATH="${PATH}:/root/.cargo/bin"

--- a/post-processor/build/Dockerfile.vv8
+++ b/post-processor/build/Dockerfile.vv8
@@ -1,2 +1,0 @@
-FROM ubuntu:latest
-COPY ./artifacts /artifacts

--- a/post-processor/build/docker.sh
+++ b/post-processor/build/docker.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 set -ex
-docker build -t vv8-postprocessor-builder -f ./build/Dockerfile.builder .
-docker run  --rm -u 0 -v $(pwd):/visiblev8 -v $(pwd)/build/rust_build_cache:/root/.cargo/registry:rw -v $(pwd)/build/go_build_cache:/go/pkg:rw  vv8-postprocessor-builder make -C /visiblev8
-docker build -t visiblev8/vv8-postprocessors:$(git rev-parse --short HEAD) -t vv8-postprocessors-local -f ./build/Dockerfile.vv8 .
+docker build -t vv8-postprocessors-local -t visiblev8/vv8-postprocessors:$(git rev-parse --short HEAD) -f ./build/Dockerfile .
+docker cp $(docker create vv8-postprocessors-local):/artifacts ./artifacts


### PR DESCRIPTION
- Create one dockerfile that is capable of building the postprocessors in Github and locally
- [HACK] Use docker cp to copy the requisite artifacts out of the Docker image into the correct directory for local development and use
- Modify the builder.sh to only build everything once
- use Docker mount caching (TIL that was a thing) to cache data like we were doing before