### PR TITLE
ci: checkout / github-script version bump

### DIFF
--- a/.github/workflows/chromium-build.yaml
+++ b/.github/workflows/chromium-build.yaml
@@ -12,7 +12,7 @@ jobs:
         timeout-minutes: 2880
 # Lets give ourselves 2 day to build VisibleV8 (github by default gives 6 hrs which is not enough time to build Chrome three times unless we use Google magic)
         steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
           with:
             fetch-depth: 0
         - name: Extract short SHA

--- a/.github/workflows/chromium-build.yaml
+++ b/.github/workflows/chromium-build.yaml
@@ -18,7 +18,7 @@ jobs:
         - name: Extract short SHA
           id: short_sha
           run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-        - uses: actions/github-script@v7
+        - uses: actions/github-script@v8
           id: get_release
           with:
             script: |
@@ -46,7 +46,7 @@ jobs:
               core.setOutput('chromeMajorVersion', chromeMajorVersion);
         - name: Diff our changes
           id: diff
-          uses: actions/github-script@v7
+          uses: actions/github-script@v8
           env:
             oldCommit: ${{ steps.get_release.outputs.commit }}
             currentCommit: ${{ steps.get_release.outputs.currentGitCommit }}
@@ -65,7 +65,7 @@ jobs:
   # Hack: We send the first letter or the string 'empty' since Github runners hang if we send over the entire diff
         - name: Should we publish ?
           id: shouldPublish
-          uses: actions/github-script@v7
+          uses: actions/github-script@v8
           env:
             GIT_DIFF: ${{ steps.diff.outputs.diff }}
           with:
@@ -135,7 +135,7 @@ jobs:
         - name: Create a release
           if: steps.shouldPublish.outputs.shouldPublish == 'true'
           id: create_release
-          uses: actions/github-script@v7
+          uses: actions/github-script@v8
           with:
             script: |
               const name = 'visiblev8_${{ steps.get_release.outputs.currentGitCommit }}-${{ steps.get_release.outputs.chromeReleaseVersion }}';

--- a/.github/workflows/on_workflow_completed.yaml
+++ b/.github/workflows/on_workflow_completed.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: [self-hosted, linux, workflow-finish-runner]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Wait for results
         run: sleep 10
       - name: Extract short SHA

--- a/.github/workflows/on_workflow_completed.yaml
+++ b/.github/workflows/on_workflow_completed.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Extract short SHA
         id: short_sha
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         id: get_release
         with:
           script: |

--- a/.github/workflows/post-processor.yaml
+++ b/.github/workflows/post-processor.yaml
@@ -21,7 +21,7 @@ jobs:
             }
 
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Resolve this
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/github-script@v7. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24.
```